### PR TITLE
import config, then config.Config didn't worked for me (and I saw iss…

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,1 +1,1 @@
-from config import *
+from config.config import *


### PR DESCRIPTION
…ues about this from others too).

As I saw in issues, people uses config.config(instead of config), but we could fix this in __init__.py file to allow user code(test.py, train.py) work.

before patch 
>>> import config
>>> config.Config().backbone
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'config' has no attribute 'Config'

after patch
>>> import config
>>> config.Config().backbone
'resnet18'